### PR TITLE
[MimasV2] Make sure VGA color lines are at 0V during blanking

### DIFF
--- a/FPGA/MimasV2/mimasV2Demo/src/MimasV2VGA/MimasV2VGADisplay.vhd
+++ b/FPGA/MimasV2/mimasV2Demo/src/MimasV2VGA/MimasV2VGADisplay.vhd
@@ -106,6 +106,10 @@ begin
                      Red <= rgb (7 downto 5);
                      Green <= rgb (4 downto 2);
                      Blue <= rgb (1 downto 0);  
+                   else
+                     Red <= b"000";
+                     Green <= b"000";
+                     Blue <= b"00";
                    end if;
                  end if;
                divide_by_2 := not divide_by_2;


### PR DESCRIPTION
This fixes an issue I had when trying to change the background color in the Mimas V2 VGA sample.

I wanted to try change some things like making the background color white (See [1]).
This resulted in a very dark output (see 1st image), probably caused by the color output lines not being 0V during the blanking period. ([2] seems to explain the observed problem).

Expected output is shown in the 2nd image (works after applying this PR and the earlier referenced change [1]).

[[1] Change to make background white](https://github.com/dennisschagt/samplecode/commit/faa6e97542eb17d9dbd27170249b02c4c3bface0)
[[2] Stack Exchange answer with explanantion](https://electronics.stackexchange.com/a/221560/24694) 

![IMG_1053](https://user-images.githubusercontent.com/4629607/60756128-16858400-9ffa-11e9-8af2-4d2e590be48e.JPG)
![IMG_1054](https://user-images.githubusercontent.com/4629607/60756124-0e2d4900-9ffa-11e9-8906-f0a87b5c2ea7.JPG)
